### PR TITLE
Procedural Tile Map Update

### DIFF
--- a/UE4/Content/2DSideScrollerBP/Blueprints/2DSideScrollerGameMode.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/2DSideScrollerGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2fbec0ed17138370c6d6e0786daedd6cf9a7e7800c4c84566162bc59f35f8fd
-size 66267
+oid sha256:554424b8f089214e88685687b27f563cd3e915f4de008638983bbaad142da7fc
+size 190594

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/Blob.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/Blob.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:087090d8e190fbef457388246af2e08ca0376f4bf8817176e59e5b41c42e3084
-size 186441
+oid sha256:a4d2ec6496f8df51f1ef533ee616a6dffbfa1eca1a0cbd57ce398cf5a84be8a6
+size 160846

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemySpawner.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemySpawner.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a33196358d69a4410df135cf71da620e4b4b7f0a20d3d70d5b2d16bcdc67eb8
-size 283375
+oid sha256:632310797da097aedc9f7956cfa240797709bcbcf8a4637ddd2b64fbcb69eca3
+size 299290

--- a/UE4/Content/ProceduralContent/Blueprints/BP_Base_Tile.uasset
+++ b/UE4/Content/ProceduralContent/Blueprints/BP_Base_Tile.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3cadfb4861e8491efcd9964ea6a8ab3fc68c35263d62b340bbf30c88b92e578
+size 55551

--- a/UE4/Content/ProceduralContent/Blueprints/BP_Tile1.uasset
+++ b/UE4/Content/ProceduralContent/Blueprints/BP_Tile1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d5de6539b0c6c721bd0b1682388b5d6bac07efae795324d860d05d60050758e
+size 154289

--- a/UE4/Content/ProceduralContent/Maps/L_Procedural_Level.umap
+++ b/UE4/Content/ProceduralContent/Maps/L_Procedural_Level.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc8e7bee58c474c61d8bc119ab53a80eb330ee4df04583da4f831fefb1ec3445
+size 638284

--- a/UE4/Content/ProceduralContent/Maps/L_Procedural_Level_BuiltData.uasset
+++ b/UE4/Content/ProceduralContent/Maps/L_Procedural_Level_BuiltData.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a80d087cdf360eea959d0d64ea4370f2ccc5bbec3efb69b29ba642cb8cdbf4
+size 1134421

--- a/UE4/Content/ProceduralContent/SP_Proc_Ledge.uasset
+++ b/UE4/Content/ProceduralContent/SP_Proc_Ledge.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c670da98f6bc1b31d6fb41dd7c2772fafd8475bf496d3328dfbee3bbb3266bb4
+size 13457

--- a/UE4/Content/ProceduralContent/Tiles/TM_Tiile_02.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/TM_Tiile_02.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:254e4b5d82b1a6d6f7287e3c324b67c5e2280de43741538a9ca847692a8b1496
+size 7387

--- a/UE4/Content/ProceduralContent/Tiles/TM_Tile_01.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/TM_Tile_01.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a59b1d52aa74afde065a4451314fc30c4271d54ed8c762aad644c12854fdab9e
+size 7487

--- a/UE4/Content/ProceduralContent/Tiles/TM_Tile_03.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/TM_Tile_03.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:680f99427eed84df444323722177deaffbf87e69c5e9af52bada61d7ce900954
+size 7487

--- a/UE4/Content/ProceduralContent/Tiles/TM_Tile_04.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/TM_Tile_04.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:855fe3a3f9e05e79867d16039e33ebb6ac9afbd606bde9ee7fe0abc3968c19a2
+size 7487

--- a/UE4/Content/ProceduralContent/Tiles/Tiles.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/Tiles.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23bfc4bf9559d721c7c7f3d1f54359b13207086df46a067b7c9db975257c158
+size 47059

--- a/UE4/Content/ProceduralContent/Tiles/Tiles_TileSet.uasset
+++ b/UE4/Content/ProceduralContent/Tiles/Tiles_TileSet.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cd6e82cc6334baa4996bf40b23feb26552152b84dc0a71d8948c2078741d06
+size 40248


### PR DESCRIPTION
Added procedural Tile generation. Tile generation is deterministic in both directions along the x-axis. Included 4 example tilemaps to demonstrate implementation. Additions have been placed in the Content/ProceduralContent folder

The main tileset is designed around a 98x98 tile size with a 2 pixel padding. This can obviously be modified, but doing so will require some tinkering with the generation algorithm to make sure everything lines up properly.

Tile and map assets keep reverting to 3D mode in the editor. This causes Larry to fall through the tiles when play testing. Setting the perspective to "Front" in the editor fixes it. This is probably just a setting I forgot to check. 

2DSideScrollerGameMode has been modified to generate the initial tile. Previous behaviour has been disconnected for testing purposes, but is otherwise unmodified.

TODO: 
Currently using placeholder art
Greater variety in tile maps
Scrolling background