### PR TITLE
Feature/one enemy per player

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Polish
  - Pulls enemies off the queue to determine which enemy type to spawn
  - Enemies are added to the queue by either RandomEnemyGenerator (for testing) or via Twitch Integration ( coming soon )
  - RandomEnemyGenerator simulates Twitch Integration by adding to the EnemyQueue random EnemyProfiles at random times
+ - There can only be one enemy alive or in the queue at a time.  This logic is handled by the EnemySpawnPermissions

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/Blob.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/Blob.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:147344fb37691a08881c446f536eb9a7fc8c5880d8930cd14836ec060e29258a
-size 192355
+oid sha256:fa48037a5c40b2f1cbc49b489401062d20352badf53e035dd26ad0acc04ce9d6
+size 189540

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueue.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueue.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b88af67b18fc6b0420db35d72ebe294f3ec5f1099ff677c4946325afad9413f
-size 57557
+oid sha256:092a8c6c2bdfcfe5da9ceb383d703695aef43e10cb49eb52ffd30d3eb31af46b
+size 103717

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueuePermissions.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueuePermissions.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8547948e82f4bf964e6ae69ed67cbfe3b0c4aa58d442af636c90c0d591a95a27
+size 56022

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemySpawner.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemySpawner.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c212a564df8115adb0122c3b6911e8c9f6ab5803628d4a117d33cc9c4d9ffd65
-size 318915
+oid sha256:86baa847ed85aa861c32cb397623bdc530f90fac9ef566e0cc2e850cff0076a4
+size 349201

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyTracker.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyTracker.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fe2abd1f09fcee97e23df6926b446c96a0f4afa80e4407cfcaabbf23a09efa5
+size 70308

--- a/UE4/Content/2DSideScrollerBP/Maps/Test_LongMap.umap
+++ b/UE4/Content/2DSideScrollerBP/Maps/Test_LongMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28e169c7bfed1ee0768bdaeb57b3d389f68d47c03d0f110b8fae47d3f2bd2c97
-size 126369
+oid sha256:1864c524ba96cbf9e325d4e9c206fe405cf94a3090af70731be0763484629ad6
+size 124172

--- a/UE4/Content/2DSideScrollerBP/Maps/Test_LongMap_BuiltData.uasset
+++ b/UE4/Content/2DSideScrollerBP/Maps/Test_LongMap_BuiltData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00dc8cb7e3b6c6c22cca01d8e004d1f8db4eabe6d8c4d0cfc317ee9241f030da
+oid sha256:8f8ae76f328b92f028f873c8ff2789a627da83cbd199f5b846c88e3105ddcb57
 size 1334


### PR DESCRIPTION
Add Queue permissions which is used for allowing enemies into queue

Checks both the Queue & Tracker to see if a specific enemy is allowed.  The idea here is that with twitch integration, if they aren't allowed to enter the queue, we can whisper back to them that they are already alive or in the queue