### PR TITLE
Feature/initial twitch integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The next phases to get to a Proof of Concept are:
    - TODO: Iron out a few issues with initial PR
    - TODO: Hook up an actual set of tiles from example content
  - Hook up twitch chat integration
+   - TODO: Save Auth token so only have to log in if auth token isn't valid
+   - TODO: Hook up loading UI for when logging into twitch
  
 Polish
  - Don't move camera until Larry gets to X percentage of the screen in either direction, so he can run back and forth without moving the camera.  
@@ -24,3 +26,8 @@ Polish
  - Enemies are added to the queue by either RandomEnemyGenerator (for testing) or via Twitch Integration ( coming soon )
  - RandomEnemyGenerator simulates Twitch Integration by adding to the EnemyQueue random EnemyProfiles at random times
  - There can only be one enemy alive or in the queue at a time.  This logic is handled by the EnemyQueuePermissions
+ 
+ Twitch Integration
+ - To enable twitch integration, download the TwitchWorks plugin & follow the instructions to enable it
+ - In EnemySpawnerGameMode, turn on the twitch integration boolean
+ - Please when making changes turn off the twitch integration and use the random enemy spawner instead, twitch integration should only be turned on for publishing

--- a/UE4/Config/DefaultProject.ini
+++ b/UE4/Config/DefaultProject.ini
@@ -1,0 +1,12 @@
+
+[/Script/TwitchSettingsPlugin.TwitchRuntimeSettings]
+clientID=mx1hf8f54c4cil3j5qpwkwo2tgwti3
+twitchLoginApiURL="http://helium-01.how2compute.cf:8080/twitch_integration_api"
+twitchLoginURL="http://helium-01.how2compute.cf:8080/perform_twitch_auth"
+shouldCacheEmoteRequests=False
++Commands=(CommandName="spawn",CommandDescription="Queues an enemy with your name to spawn in the game for Larry to fight!",Parameters=,showsUpInHelp=True)
+commandPrefix=!
+bIsCommandHelpEnabled=True
+helpCommand=help
+
+

--- a/UE4/Content/2DSideScrollerBP/Blueprints/2dSideScrollerPlayerController.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/2dSideScrollerPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8226e1819e305ef0d9bb74ae47a69f24cc03d40542114fa9b03aec20cbd962d3
-size 37923
+oid sha256:810b4242e924490def24ed1a9f3eb688bd03c6a6241e5f3e77920f17f47a3f60
+size 37665

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyProfile.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyProfile.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:411a6816e9cc902c5724c287de1e0e42cdfd65842ba49d0a44c9776b6d830ffc
-size 10804
+oid sha256:07ce5ad16d634c3dcdf0dee10352d175b9aada8ebd6434822209287a50d05370
+size 30754

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueue.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/EnemyQueue.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:092a8c6c2bdfcfe5da9ceb383d703695aef43e10cb49eb52ffd30d3eb31af46b
-size 103717
+oid sha256:6b6e7d5699ec5be1ab7949364e27d76dfbdac3c8c61694649d57ea71e756655f
+size 105755

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/RandomEnemyGenerator.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/RandomEnemyGenerator.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3df4ed1468b87247ce38c4496ef32260beda9507ecc56fb38ec9106715163fc1
-size 88848
+oid sha256:6a1558ea02d7131d031def86d29b395a27d8614123ed42f64d08ed1ac021fcf0
+size 90483

--- a/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/TwitchEnemyGenerator.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/Enemies/TwitchEnemyGenerator.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22c63b25819d8a26ec6cb62b12e01a30f7bb8a44382b0709499a4ce44d10b52c
+size 76389

--- a/UE4/Content/2DSideScrollerBP/Blueprints/GameModes/BaseGameMode.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/GameModes/BaseGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5c55b7dbadd9db087690732fa7a09b02934be0e4487c3eb6543dc80b7cb5939
-size 54671
+oid sha256:5b2532d9d37c9d54604ba7277864627c7f2ac29cd46ec8fdb0051aaa082f7d6a
+size 66321

--- a/UE4/Content/2DSideScrollerBP/Blueprints/GameModes/EnemySpawnerGameMode.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/GameModes/EnemySpawnerGameMode.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cda74b9e25b74b4df8d2fd58d671249f689c4b14ff1f435e4c0d175a73630c5b
-size 43482
+oid sha256:9d19daa39cc1b6716d2e982de0d9ac28cc42cf42be4f8443dcf669abe1228561
+size 64976

--- a/UE4/Content/2DSideScrollerBP/Blueprints/TwitchAuth.uasset
+++ b/UE4/Content/2DSideScrollerBP/Blueprints/TwitchAuth.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e87365e36bdc48b295945290ed3545fc248145d30c4ce3937f91c0bbafb15a70
+size 94983

--- a/UE4/LUL2DSS.uproject
+++ b/UE4/LUL2DSS.uproject
@@ -7,6 +7,11 @@
 		{
 			"Name": "Paper2D",
 			"Enabled": true
+		},
+		{
+			"Name": "TwitchWorks",
+			"Enabled": false,
+			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/50ad7661b7274a408034fc4ad7e4aa82"
 		}
 	]
 }


### PR DESCRIPTION
 Twitch Integration
 - To enable twitch integration, download the TwitchWorks plugin & follow the instructions to enable it
 - In EnemySpawnerGameMode, turn on the twitch integration boolean
 - Please when making changes turn off the twitch integration and use the random enemy spawner instead, twitch integration should only be turned on for publishing